### PR TITLE
Add shortcut to activate the toolbar window for Firefox

### DIFF
--- a/src/manifest-firefox.json
+++ b/src/manifest-firefox.json
@@ -32,9 +32,25 @@
     "storage",
     "tabs",
     "<all_urls>",
-    "theme"  
+    "theme"
   ],
-  "optional_permissions": [    
-
-]
+  "optional_permissions": [],
+  "commands": {
+    "_execute_browser_action": {},
+    "toggle": {
+      "suggested_key": {
+        "default": "Alt+Shift+D"
+      },
+      "description": "__MSG_toggle_extension__"
+    },
+    "addSite": {
+      "suggested_key": {
+        "default": "Alt+Shift+A"
+      },
+      "description": "__MSG_toggle_current_site__"
+    },
+    "switchEngine": {
+      "description": "__MSG_theme_generation_mode__"
+    }
+  }
 }


### PR DESCRIPTION
Firefox does not automatically add the shortcut for extensions to activate the toolbar window, making it inconvenient when frequently using the popup to modify site themes.

This PR adds this feature by modifying the manifest.